### PR TITLE
Use UTC for date formatting

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -8,7 +8,7 @@ var through2 = require('through2');
 var concat = require('concat-stream');
 var sprintf = require('sprintf');
 var spawn = require('child_process').spawn;
-var strftime = require('strftime');
+var strftime = require('strftime').strftimeUTC;
 var os = require('os');
 var table = require('text-table');
 


### PR DESCRIPTION
Fixes the off-by-one errors as mentioned in #12.