### PR TITLE
Only write updated config file on pdf success

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -192,10 +192,8 @@ function withConfig (cfg, expenses) {
         }
         fs.createReadStream(path.join(tmpdir, 'invoice.pdf'))
             .pipe(fs.createWriteStream(outfile))
-        ;
+        writeConfig(cfg);
     });
-    
-    writeConfig(cfg);
 }
 
 function writeConfig (cfg) {


### PR DESCRIPTION
What would happen previous is `id` in the config would get incremented even if
`pdflatex` returned a bad exit code.